### PR TITLE
Updating bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "polyfill"
   ],
   "license": "Apache 2.0",
+  "main": "dist/hidpi-canvas.js",
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
Adding `main` property to `bower.json` file which allows building tools to use the file to copy the dependency correctly.
